### PR TITLE
trim line break from stdout

### DIFF
--- a/tasks/nvm/alias-default.js
+++ b/tasks/nvm/alias-default.js
@@ -30,7 +30,7 @@ module.exports = function (gruntOrShipit) {
       )
       .then(function (res) {
 
-        v = remote ? res[0].stdout : res.stdout;
+        v = (remote ? res[0].stdout : res.stdout).trim();
 
         return shipit[method](
           sprintf('. %s && nvm use %s && nvm alias default %s', shipit.config.nvm.sh, v, v)


### PR DESCRIPTION
to alias default from `.nvmrc` file.

```
Running 'nvm:alias-default' task...
Running "cat /home/geta6/project/releases/20150810040702/.nvmrc" on host "0.0.0.0".
@0.0.0.0 iojs-v2.5.0
Running ". ~/.nvm/nvm.sh && nvm use iojs-v2.5.0
 && nvm alias default iojs-v2.5.0
" on host "0.0.0.0".
@0.0.0.0-err zsh:2: parse error near `&&'
Error: Command failed: /bin/sh -c ssh geta6@0.0.0.0 ". ~/.nvm/nvm.sh && nvm use iojs-v2.5.0
 && nvm alias default iojs-v2.5.0
"
zsh:2: parse error near `&&'

Finished 'nvm:alias-default' after 275 ms
```
